### PR TITLE
fix: add part attribute for starknetkit modal for css override

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,7 @@ export const connect = async ({
   })
 
   const getTarget = (): ShadowRoot => {
-    const modalId = "starknetkit-modal"
+    const modalId = "starknetkit-modal-container"
     const existingElement = document.getElementById(modalId)
 
     if (existingElement) {

--- a/src/modal/Modal.svelte
+++ b/src/modal/Modal.svelte
@@ -71,6 +71,7 @@
 {#if !isInAppBrowser && modalWallets.length > 1}
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
+    part="starknetkit-modal"
     class={`modal-font backdrop-blur-sm fixed inset-0 flex items-center 
             justify-center bg-black/25 z-[9999] ${darkModeControlClass}`}
     on:click={() => cb(null)}


### PR DESCRIPTION
usage example:

```css
#starknetkit-modal-container::part(starknetkit-modal){
  z-index: 1;
}
```