### PR TITLE
fix: add id for argent mobile modal container div

### DIFF
--- a/src/connectors/argentMobile/modal/argentModal.ts
+++ b/src/connectors/argentMobile/modal/argentModal.ts
@@ -41,7 +41,7 @@ const iframeStyle = {
 }
 
 const overlayHtml = `
-  <div style="position: relative">
+  <div id="argent-mobile-modal-container" style="position: relative">
     <iframe class="argent-iframe" allow="clipboard-write"></iframe>
     <div class="argent-close-button" style="position: absolute; top: 24px; right: 24px; cursor: pointer;">
       <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
add `id` for div container for argent mobile modal

this will allow an easier css override if needed