### PR TITLE
Fix/wallets ordering and reconnect

### DIFF
--- a/src/helpers/mapModalWallets.ts
+++ b/src/helpers/mapModalWallets.ts
@@ -25,7 +25,16 @@ export const mapModalWallets = ({
     return []
   }
 
-  return availableConnectors
+  const allInstalledWallets = installedWallets.map((w) =>
+    availableConnectors.find((c) => c.id === w.id),
+  )
+
+  const orderedByInstall = [
+    ...availableConnectors.filter((c) => allInstalledWallets.includes(c)),
+    ...availableConnectors.filter((c) => !allInstalledWallets.includes(c)),
+  ]
+
+  const connectors = orderedByInstall
     .map<ModalWallet | null>((c) => {
       const installed = installedWallets.find((w) => w.id === c.id)
       if (installed) {
@@ -74,4 +83,6 @@ export const mapModalWallets = ({
       }
     })
     .filter((c): c is ModalWallet => c !== null)
+
+  return connectors
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,17 +48,22 @@ export const connect = async ({
 
   const lastWalletId = localStorage.getItem("starknetLastConnectedWallet")
   if (modalMode === "neverAsk") {
-    const connector = availableConnectors.find((c) => c.id === lastWalletId)
+    try {
+      const connector = availableConnectors.find((c) => c.id === lastWalletId)
 
-    if (resultType === "wallet") {
-      await connector?.connect()
-    }
+      if (resultType === "wallet") {
+        await connector?.connect()
+      }
 
-    selectedConnector = connector ?? null
+      selectedConnector = connector ?? null
 
-    return {
-      connector,
-      wallet: connector?.wallet ?? null,
+      return {
+        connector,
+        wallet: connector?.wallet ?? null,
+      }
+    } catch (error) {
+      removeStarknetLastConnectedWallet()
+      throw new Error(error)
     }
   }
 


### PR DESCRIPTION
in this example, the original order was

braavos (not installed)
argent-x 
argent mobile
argent webwallet

after ordering by installed wallets:

![image](https://github.com/argentlabs/starknetkit/assets/7635032/83996fb9-e26f-414c-b315-7ad479e6f320)
