### PR TITLE
fix: inAppBrowserOptions as optional

### DIFF
--- a/src/connectors/argentMobile/index.ts
+++ b/src/connectors/argentMobile/index.ts
@@ -246,7 +246,7 @@ export class ArgentMobileBaseConnector extends Connector {
 
 export interface ArgentMobileConnectorInitParams {
   options: ArgentMobileConnectorOptions
-  inAppBrowserOptions: Omit<InjectedConnectorOptions, "id">
+  inAppBrowserOptions?: Omit<InjectedConnectorOptions, "id">
 }
 
 export class ArgentMobileConnector {


### PR DESCRIPTION
### Issue / feature description

make `inAppBrowserOptions` optional for `ArgentMobileConnector`
`id: argentX` is always passed to the `InjectedConnector` if the context is the in-app argent app browser


### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
