### PR TITLE
fix: remove ensure wallet in argent mobile and argent webwallet 

### DIFF
--- a/src/connectors/argentMobile/index.ts
+++ b/src/connectors/argentMobile/index.ts
@@ -56,18 +56,19 @@ export class ArgentMobileBaseConnector extends Connector {
   }
 
   async ready(): Promise<boolean> {
-    // check if session is valid and retrieve the wallet
-    // if no sessions, it will show the login modal
-    await this.ensureWallet()
     if (!this._wallet) {
       return false
     }
 
-    const permissions = await this._wallet.request({
-      type: "wallet_getPermissions",
-    })
+    try {
+      const permissions = await this._wallet.request({
+        type: "wallet_getPermissions",
+      })
 
-    return (permissions as Permission[]).includes(Permission.ACCOUNTS)
+      return (permissions as Permission[]).includes(Permission.ACCOUNTS)
+    } catch {
+      return false
+    }
   }
 
   get id(): string {
@@ -150,8 +151,6 @@ export class ArgentMobileBaseConnector extends Connector {
   async request<T extends RpcMessage["type"]>(
     call: RequestFnCall<T>,
   ): Promise<RpcTypeToMessageMap[T]["result"]> {
-    this.ensureWallet()
-
     if (!this._wallet) {
       throw new ConnectorNotConnectedError()
     }

--- a/src/connectors/webwallet/index.ts
+++ b/src/connectors/webwallet/index.ts
@@ -54,11 +54,15 @@ export class WebWalletConnector extends Connector {
     }
 
     this._wallet = _wallet
-    const permissions = await this._wallet.request({
-      type: "wallet_getPermissions",
-    })
+    try {
+      const permissions = await this._wallet.request({
+        type: "wallet_getPermissions",
+      })
 
-    return (permissions as Permission[]).includes(Permission.ACCOUNTS)
+      return (permissions as Permission[]).includes(Permission.ACCOUNTS)
+    } catch {
+      return false
+    }
   }
 
   get id(): string {


### PR DESCRIPTION
### Issue / feature description

Remove argent mobile and argent webwallet popups when a request is performed (just throw an exception and the dapp will have to manage it)

required for being compatible with starknet-react, since it will always make a request while checking if the connector is connected (and, in this case, it shouldn't open mobile popup login / webwallet)

### Changes

- remove `this.ensureWallet()` for Argent Mobile connector
- remove `this.ensureWallet()` for Argent Webwallet connector

### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [ ] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
