### PR TITLE
feat: upgrade argent webwallet connect with one call

### DIFF
--- a/src/connectors/webwallet/helpers/openWebwallet.ts
+++ b/src/connectors/webwallet/helpers/openWebwallet.ts
@@ -76,7 +76,7 @@ export const openWebwallet = async (
     const iframeTrpcProxyClient = trpcProxyClient({
       iframe: iframe.contentWindow ?? undefined,
     })
-    await iframeTrpcProxyClient.authorize.mutate()
+
     const starknetWindowObject = await getWebWalletStarknetObject(
       origin,
       iframeTrpcProxyClient,

--- a/src/connectors/webwallet/helpers/trpc.ts
+++ b/src/connectors/webwallet/helpers/trpc.ts
@@ -1,3 +1,4 @@
+import { Permission } from "@starknet-io/types-js"
 import type { CreateTRPCProxyClient } from "@trpc/client"
 import { createTRPCProxyClient, loggerLink, splitLink } from "@trpc/client"
 import { initTRPC } from "@trpc/server"
@@ -10,7 +11,6 @@ import {
   deployAccountContractSchema,
 } from "../../../types/window"
 import { DEFAULT_WEBWALLET_URL } from "../constants"
-import { Permission } from "@starknet-io/types-js"
 
 const t = initTRPC.create({
   isServer: false,
@@ -60,6 +60,14 @@ const appRouter = t.router({
     return true
   }),
   connect: t.procedure.mutation(async () => ""),
+  connectWebwallet: t.procedure
+    .output(
+      z.object({
+        account: z.string().array().optional(),
+        chainId: z.string().optional(),
+      }),
+    )
+    .mutation(async () => ({})),
   enable: t.procedure.output(z.string()).mutation(async () => ""),
   execute: t.procedure
     .input(StarknetMethodArgumentsSchemas.execute)

--- a/src/connectors/webwallet/starknetWindowObject/argentStarknetWindowObject.ts
+++ b/src/connectors/webwallet/starknetWindowObject/argentStarknetWindowObject.ts
@@ -1,5 +1,3 @@
-import type { CreateTRPCProxyClient } from "@trpc/client"
-import type { constants } from "starknet"
 import type {
   AccountChangeEventHandler,
   NetworkChangeEventHandler,
@@ -7,6 +5,8 @@ import type {
   StarknetWindowObject,
   WalletEvents,
 } from "@starknet-io/types-js"
+import type { CreateTRPCProxyClient } from "@trpc/client"
+import type { constants } from "starknet"
 import {
   EXECUTE_POPUP_HEIGHT,
   EXECUTE_POPUP_WIDTH,
@@ -35,7 +35,12 @@ export type LoginStatus = {
 
 export type WebWalletStarknetWindowObject = StarknetWindowObject & {
   getLoginStatus(): Promise<LoginStatus>
+  connectWebwallet(): Promise<{
+    account?: string[]
+    chainId?: string
+  }>
 }
+
 export const getArgentStarknetWindowObject = (
   options: GetArgentStarknetWindowObject,
   proxyLink: CreateTRPCProxyClient<AppRouter>,
@@ -44,6 +49,9 @@ export const getArgentStarknetWindowObject = (
     ...options,
     getLoginStatus: () => {
       return proxyLink.getLoginStatus.mutate()
+    },
+    connectWebwallet: () => {
+      return proxyLink.connectWebwallet.mutate()
     },
     async request(call) {
       switch (call.type) {


### PR DESCRIPTION
### Issue / feature description

Right now, webwallet performs 2 calls for iframe (requestAccounts and requestChainId) and 3 for a popup (`.authorize` endpoint on trpc).

With this change, everything is done with one call (improving UX).

This change requires a webwallet upgrade too (so this pr will be merged **`after`** webwallet is updated)

### Changes

- update WebwalletStarknetWindowObject
- update `connect` method on webwallet connector
- remove `authorize` trpc mutation

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
