### PR TITLE
Fix/connectors account

### DIFF
--- a/src/connectors/argentMobile/index.ts
+++ b/src/connectors/argentMobile/index.ts
@@ -1,18 +1,18 @@
 import { type AccountChangeEventHandler } from "@starknet-io/get-starknet-core"
 import {
-  AccountInterface,
-  ProviderInterface,
-  ProviderOptions,
-  WalletAccount,
-  constants,
-} from "starknet"
-import {
   Permission,
   RequestFnCall,
   RpcMessage,
   RpcTypeToMessageMap,
   type StarknetWindowObject,
 } from "@starknet-io/types-js"
+import {
+  Account,
+  AccountInterface,
+  ProviderInterface,
+  ProviderOptions,
+  constants,
+} from "starknet"
 import {
   ConnectorNotConnectedError,
   ConnectorNotFoundError,
@@ -27,10 +27,10 @@ import {
   type ConnectorData,
   type ConnectorIcons,
 } from "../connector"
-import { DEFAULT_ARGENT_MOBILE_ICON, DEFAULT_PROJECT_ID } from "./constants"
-import type { StarknetAdapter } from "./modal/starknet/adapter"
-import { isInArgentMobileAppBrowser } from "./helpers"
 import { InjectedConnector, InjectedConnectorOptions } from "../injected"
+import { DEFAULT_ARGENT_MOBILE_ICON, DEFAULT_PROJECT_ID } from "./constants"
+import { isInArgentMobileAppBrowser } from "./helpers"
+import type { StarknetAdapter } from "./modal/starknet/adapter"
 
 export interface ArgentMobileConnectorOptions {
   dappName: string
@@ -131,8 +131,12 @@ export class ArgentMobileBaseConnector extends Connector {
     if (!this._wallet) {
       throw new ConnectorNotConnectedError()
     }
+    const accounts = await this._wallet.request({
+      type: "wallet_requestAccounts",
+      params: { silent_mode: true },
+    })
 
-    return new WalletAccount(provider, this._wallet)
+    return new Account(provider, accounts[0], "")
   }
 
   async chainId(): Promise<bigint> {

--- a/src/connectors/injected/index.ts
+++ b/src/connectors/injected/index.ts
@@ -1,16 +1,16 @@
 import {
-  AccountInterface,
-  ProviderInterface,
-  ProviderOptions,
-  WalletAccount,
-} from "starknet"
-import {
   Permission,
   RequestFnCall,
   RpcMessage,
   RpcTypeToMessageMap,
   type StarknetWindowObject,
 } from "@starknet-io/types-js"
+import {
+  Account,
+  AccountInterface,
+  ProviderInterface,
+  ProviderOptions,
+} from "starknet"
 import {
   ConnectorNotConnectedError,
   ConnectorNotFoundError,
@@ -130,7 +130,12 @@ export class InjectedConnector extends Connector {
       throw new ConnectorNotConnectedError()
     }
 
-    return new WalletAccount(provider, this._wallet)
+    const accounts = await this.request({
+      type: "wallet_requestAccounts",
+      params: { silent_mode: true },
+    })
+
+    return new Account(provider, accounts[0], "")
   }
 
   async connect(): Promise<ConnectorData> {

--- a/src/connectors/webwallet/index.ts
+++ b/src/connectors/webwallet/index.ts
@@ -52,6 +52,7 @@ export class WebWalletConnector extends Connector {
   async ready(): Promise<boolean> {
     if (!_wallet) {
       this._wallet = null
+      _address = null
       return false
     }
 
@@ -200,6 +201,7 @@ export class WebWalletConnector extends Connector {
     this._wallet.off("accountsChanged", accountChangeCb)
 
     _wallet = null
+    _address = null
     this._wallet = null
   }
 

--- a/src/connectors/webwallet/index.ts
+++ b/src/connectors/webwallet/index.ts
@@ -7,10 +7,10 @@ import {
   type StarknetWindowObject,
 } from "@starknet-io/types-js"
 import {
+  Account,
   AccountInterface,
   ProviderInterface,
   ProviderOptions,
-  WalletAccount,
 } from "starknet"
 import {
   ConnectorNotConnectedError,
@@ -30,6 +30,7 @@ import { setPopupOptions } from "./helpers/trpc"
 import type { WebWalletStarknetWindowObject } from "./starknetWindowObject/argentStarknetWindowObject"
 
 let _wallet: StarknetWindowObject | null = null
+let _address: string | null = null
 
 interface WebWalletConnectorOptions {
   url?: string
@@ -116,6 +117,8 @@ export class WebWalletConnector extends Connector {
 
       const hexChainId = getStarknetChainId(chainId)
 
+      _address = account[0]
+
       return {
         account: account[0],
         chainId: BigInt(hexChainId),
@@ -145,6 +148,7 @@ export class WebWalletConnector extends Connector {
     }
 
     _wallet = null
+    _address = null
     this._wallet = _wallet
     removeStarknetLastConnectedWallet()
   }
@@ -158,7 +162,11 @@ export class WebWalletConnector extends Connector {
       throw new ConnectorNotConnectedError()
     }
 
-    return new WalletAccount(provider, this._wallet)
+    if (!_address) {
+      throw new ConnectorNotConnectedError()
+    }
+
+    return new Account(provider, _address, "")
   }
 
   async chainId(): Promise<bigint> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,9 +139,8 @@ export const connect = async ({
         callback: async (connector: StarknetkitConnector | null) => {
           try {
             selectedConnector = connector
-            const connectorData = (await connector?.connect()) ?? null
-
             if (resultType === "wallet") {
+              const connectorData = (await connector?.connect()) ?? null
               if (connector !== null) {
                 setStarknetLastConnectedWallet(connector.id)
               }
@@ -155,7 +154,7 @@ export const connect = async ({
               resolve({
                 connector,
                 wallet: null,
-                connectorData,
+                connectorData: null,
               })
             }
           } catch (error) {


### PR DESCRIPTION
### Issue / feature description

- `account` method for connectors are using starknetjs `WalletAccount`

this is causing issues for webwallet and argent in app browsers since a request is performed in the constructor
```typescript
walletProvider
      .request({
        type: 'wallet_requestAccounts',
        params: {
          silent_mode: false,
        },
      })
      .then((res) => {
        this.address = res[0].toLowerCase();
      });
```

This call will display an additional popup for webwallet and in app browser connection due to the wallet request

### Changes
- update `account` method to use an `Account` instead of `WalletAccount` since the return type is an `AccountInterface` anyway
- connect callback doesn't perform `connector.connect()` if the resultType is `connector`

### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [ ] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
