### PR TITLE
fix: add params to connect method and update starknetkit modal to use…

### DIFF
--- a/src/connectors/connector.ts
+++ b/src/connectors/connector.ts
@@ -28,6 +28,10 @@ export interface ConnectorEvents {
   disconnect(): void
 }
 
+export type ConnectOptions = {
+  silent_mode: boolean
+}
+
 export abstract class Connector extends EventEmitter<ConnectorEvents> {
   /** Unique connector id. */
   abstract get id(): string
@@ -41,7 +45,7 @@ export abstract class Connector extends EventEmitter<ConnectorEvents> {
   /** Whether connector is already authorized */
   abstract ready(): Promise<boolean>
   /** Connect wallet. */
-  abstract connect(): Promise<ConnectorData>
+  abstract connect(params?: ConnectOptions): Promise<ConnectorData>
   /** Disconnect wallet. */
   abstract disconnect(): Promise<void>
   /** Get current account silently. Return null if the account is not authorized */

--- a/src/connectors/injected/index.ts
+++ b/src/connectors/injected/index.ts
@@ -18,6 +18,7 @@ import {
 } from "../../errors"
 import { removeStarknetLastConnectedWallet } from "../../helpers/lastConnected"
 import {
+  ConnectOptions,
   Connector,
   type ConnectorData,
   type ConnectorIcons,
@@ -138,7 +139,7 @@ export class InjectedConnector extends Connector {
     return new Account(provider, accounts[0], "")
   }
 
-  async connect(): Promise<ConnectorData> {
+  async connect(params: ConnectOptions): Promise<ConnectorData> {
     this.ensureWallet()
 
     if (!this._wallet) {
@@ -147,9 +148,16 @@ export class InjectedConnector extends Connector {
 
     let accounts: string[]
     try {
-      accounts = await this.request({
-        type: "wallet_requestAccounts",
-      })
+      accounts = await this.request(
+        params
+          ? {
+              type: "wallet_requestAccounts",
+              params,
+            }
+          : {
+              type: "wallet_requestAccounts",
+            },
+      )
     } catch {
       throw new UserRejectedRequestError()
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,9 @@ export const connect = async ({
       let connectorData: ConnectorData | null = null
 
       if (connector && resultType === "wallet") {
-        connectorData = await connector.connect()
+        connectorData = await connector.connect({
+          silent_mode: true,
+        })
       }
 
       return {


### PR DESCRIPTION
### Issue / feature description

Argent mobile in app browser always shows the connect modal on autoconnect
this is because the injected connector doesn't support the param `silent_mode`

### Changes

- updated `connect` method adding `params` as optional (to keep compatibility with starknet-react)
- update `connect` function in `main.ts` when modalMode is `neverAsk` to use `silent_mode: true`

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
