### PR TITLE
Chore: set `options` as optional in `useStarknetkitConnectModal`

### DIFF
--- a/src/hooks/useStarknetkitConnectModal.ts
+++ b/src/hooks/useStarknetkitConnectModal.ts
@@ -6,12 +6,12 @@ type UseStarknetkitConnectors = {
 }
 
 const useStarknetkitConnectModal = (
-  options: ConnectOptionsWithConnectors,
+  options?: ConnectOptionsWithConnectors,
 ): UseStarknetkitConnectors => {
   const starknetkitConnectModal = async (): Promise<ModalResult> => {
     return await connect({
       ...options,
-      resultType: options.resultType ?? "connector",
+      resultType: options?.resultType ?? "connector",
     })
   }
 


### PR DESCRIPTION
### Issue / feature description

All properties under `ConnectOptionsWithConnectors` are already optional so, it makes no sense to require options.

### Changes

Change signature of `useStarknetkitConnectModal`

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally