### PR TITLE
fix: remove duplicate InjectedConnectorOptions

### DIFF
--- a/src/connectors/injected/index.ts
+++ b/src/connectors/injected/index.ts
@@ -27,15 +27,6 @@ import {
   WALLET_NOT_FOUND_ICON_DARK,
   WALLET_NOT_FOUND_ICON_LIGHT,
 } from "./constants"
-/** Injected connector options. */
-export interface InjectedConnectorOptions {
-  /** The wallet id. */
-  id: string
-  /** Wallet human readable name. */
-  name?: string
-  /** Wallet icons. */
-  icon?: ConnectorIcons
-}
 
 export interface InjectedConnectorOptions {
   /** The wallet id. */


### PR DESCRIPTION
### Issue / feature description

There are two identical interfaces `InjectedConnectorOptions`

### Changes

- removed duplicate interface `InjectedConnectorOptions`

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
