### PR TITLE
fix: throw error from `requestWallet` if caught error has `message` prop

### DIFF
--- a/src/connectors/argentMobile/modal/starknet/adapter.ts
+++ b/src/connectors/argentMobile/modal/starknet/adapter.ts
@@ -189,7 +189,7 @@ export class StarknetAdapter
       if (error instanceof Error || (error && error.message !== undefined)) {
         throw new Error(error.message)
       }
-      throw new Error("Unknow error on requestWallet")
+      throw new Error("Unknown error on requestWallet")
     }
   }
 


### PR DESCRIPTION
### Issue / feature description

The connector for Argent mobile was throwing `"Unknow error on requestWallet"` error because the caught error is not `instanceof Error`. 

### Changes

- Throw error if caught error has `message` property on it.

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally
