### PR TITLE
fix: set initial width and height styles for iframe

### DIFF
--- a/src/connectors/webwallet/starknetWindowObject/wormhole.ts
+++ b/src/connectors/webwallet/starknetWindowObject/wormhole.ts
@@ -1,3 +1,5 @@
+import { ENABLE_POPUP_HEIGHT, ENABLE_POPUP_WIDTH } from "../helpers/popupSizes"
+
 const applyModalStyle = (iframe: HTMLIFrameElement) => {
   iframe.style.display = "none"
   iframe.style.borderRadius = "40px"
@@ -8,6 +10,8 @@ const applyModalStyle = (iframe: HTMLIFrameElement) => {
   iframe.style.transform = "translate(-50%, -50%)"
   iframe.style.backgroundColor = "transparent"
   iframe.style.zIndex = "999999"
+  iframe.style.height = `${ENABLE_POPUP_HEIGHT}px`
+  iframe.style.width = `${ENABLE_POPUP_WIDTH}px`
 }
 
 export const showModal = (


### PR DESCRIPTION
### Issue / feature description

Iframe looks like this right now. Setting the initial height and width fixes this.

![image](https://github.com/user-attachments/assets/d668b4fd-1c51-4207-8b62-d6e805f62075)

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested