### PR TITLE
fix: replace blast nodes with chainstack (blast is sunsetting)

### DIFF
--- a/src/helpers/publicRcpNodes.ts
+++ b/src/helpers/publicRcpNodes.ts
@@ -4,9 +4,11 @@ export type PublicRpcNode = {
 }
 
 // Public RPC nodes
-export const BLAST_RPC_NODE: PublicRpcNode = {
-  mainnet: "https://starknet-mainnet.public.blastapi.io",
-  testnet: "https://starknet-sepolia.public.blastapi.io",
+export const CHAINSTACK_RPC_NODE: PublicRpcNode = {
+  mainnet:
+    "https://starknet-mainnet.core.chainstack.com/5b78befd1967e1ab160a38e1b7fa77db",
+  testnet:
+    "https://starknet-sepolia.core.chainstack.com/c35d78cd3e49108a4598e148cb569b90",
 } as const
 
 export const LAVA_RPC_NODE: PublicRpcNode = {
@@ -14,7 +16,7 @@ export const LAVA_RPC_NODE: PublicRpcNode = {
   testnet: "https://rpc.starknet-sepolia.lava.build",
 } as const
 
-export const PUBLIC_RPC_NODES = [BLAST_RPC_NODE, LAVA_RPC_NODE] as const
+export const PUBLIC_RPC_NODES = [CHAINSTACK_RPC_NODE, LAVA_RPC_NODE] as const
 
 export function getRandomPublicRPCNode() {
   const randomIndex = Math.floor(Math.random() * PUBLIC_RPC_NODES.length)


### PR DESCRIPTION
### Issue / feature description

Replacing Blast Node URLs with Chainstack, because Blast is sunsetting.
