### PR TITLE
feat: migrate starknetkit to starknet v9 and align connector types

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,8 +107,8 @@
   "dependencies": {
     "@argent/x-ui": "^1.109.0",
     "@cartridge/controller": "^0.12.1",
-    "@starknet-io/get-starknet": "^4.0.8",
-    "@starknet-io/get-starknet-core": "^4.0.8",
+    "@starknet-io/get-starknet": "4.0.8",
+    "@starknet-io/get-starknet-core": "4.0.8",
     "@starknet-io/types-js": "0.8.4",
     "@trpc/client": "^10.38.1",
     "@trpc/server": "^10.38.1",
@@ -154,7 +154,7 @@
     "prettier": "^3.0.3",
     "prettier-plugin-import-sort": "^0.0.7",
     "semantic-release": "^24.0.0",
-    "starknet": "^8.5.2",
+    "starknet": "9.1.1",
     "svelte": "^4.0.0",
     "svelte-check": "^3.5.1",
     "svelte-eslint-parser": "^0.41.1",
@@ -169,7 +169,7 @@
     "zod": "^3.20.6"
   },
   "peerDependencies": {
-    "starknet": "^8.0.0"
+    "starknet": ">=9.0.0"
   },
   "gitHead": "b16688a8638cc138938e74e1a39d004760165d75"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,10 @@ importers:
         specifier: ^0.12.1
         version: 0.12.1(@types/react@18.3.24)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@starknet-io/get-starknet':
-        specifier: ^4.0.8
+        specifier: 4.0.8
         version: 4.0.8
       '@starknet-io/get-starknet-core':
-        specifier: ^4.0.8
+        specifier: 4.0.8
         version: 4.0.8
       '@starknet-io/types-js':
         specifier: 0.8.4
@@ -151,8 +151,8 @@ importers:
         specifier: ^24.0.0
         version: 24.2.7(typescript@5.9.2)
       starknet:
-        specifier: ^8.5.2
-        version: 8.5.2
+        specifier: 9.1.1
+        version: 9.1.1(typescript@5.9.2)(zod@3.25.76)
       svelte:
         specifier: ^4.0.0
         version: 4.2.20
@@ -197,6 +197,9 @@ packages:
 
   '@adraffy/ens-normalize@1.11.0':
     resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1091,6 +1094,10 @@ packages:
     resolution: {integrity: sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/hashes@1.6.1':
+    resolution: {integrity: sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/hashes@1.7.0':
     resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
     engines: {node: ^14.21.3 || >=16}
@@ -1612,8 +1619,14 @@ packages:
   '@starknet-io/get-starknet-core@4.0.8':
     resolution: {integrity: sha512-UCyaO5T+5IZN1qPiQhLPzCSmoy06FU42tZtDmpj0UifSP7vdSMe+KRnkegiikpPJ8wZmel1o26GQkBFoUrHQlQ==}
 
+  '@starknet-io/get-starknet-wallet-standard@5.0.0':
+    resolution: {integrity: sha512-isDNGDlp16W24HE4IuweYXLDRZN0JbsDnazAieeKXE87Mn+jqhsjgTsMxcwWTjX7v906Bjz39FiDjGUddnr36g==}
+
   '@starknet-io/get-starknet@4.0.8':
     resolution: {integrity: sha512-51qlJqQMQnpW9MwvVUzOsnuSK0YbP88EEuzFbVDmtvMICuOjZd+Dr7CYgF/yK2sVbX8eA/hmY74/9S1vIWhptg==}
+
+  '@starknet-io/types-js@0.10.0':
+    resolution: {integrity: sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==}
 
   '@starknet-io/types-js@0.7.10':
     resolution: {integrity: sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==}
@@ -1623,6 +1636,9 @@ packages:
 
   '@starknet-io/types-js@0.9.1':
     resolution: {integrity: sha512-ngLjOFuWOI4EFij8V+nl5tgHVACr6jqgLNUQbgD+AgnTcAN33SemBPXDIsovwK1Mz1U04Cz3qjDOnTq7067ZQw==}
+
+  '@starknet-io/types-js@0.9.2':
+    resolution: {integrity: sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg==}
 
   '@sveltejs/vite-plugin-svelte-inspector@1.0.4':
     resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
@@ -2047,6 +2063,14 @@ packages:
 
   '@vue/shared@3.5.21':
     resolution: {integrity: sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==}
+
+  '@wallet-standard/base@1.1.0':
+    resolution: {integrity: sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==}
+    engines: {node: '>=16'}
+
+  '@wallet-standard/features@1.1.0':
+    resolution: {integrity: sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==}
+    engines: {node: '>=16'}
 
   '@walletconnect/core@2.21.0':
     resolution: {integrity: sha512-o6R7Ua4myxR8aRUAJ1z3gT9nM+jd2B2mfamu6arzy1Cc6vi10fIwFWb6vg3bC8xJ6o9H3n/cN5TOW3aA9Y1XVw==}
@@ -4359,6 +4383,9 @@ packages:
   lossless-json@4.2.0:
     resolution: {integrity: sha512-bsHH3x+7acZfqokfn9Ks/ej96yF/z6oGGw1aBmXesq4r3fAjhdG4uYuqzDgZMk5g1CZUd5w3kwwIp9K1LOYUiA==}
 
+  lossless-json@4.3.0:
+    resolution: {integrity: sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==}
+
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
@@ -4830,6 +4857,14 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  ox@0.4.4:
+    resolution: {integrity: sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   ox@0.6.7:
     resolution: {integrity: sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==}
@@ -5765,6 +5800,10 @@ packages:
 
   starknet@8.5.2:
     resolution: {integrity: sha512-d/GNASyo569y2kNZX+qS8faVxANyVANeEZWhwq0B7jVGcU6gE9W/aPThz3fMT3QN/srm+2XEiGTYbKuX+w5IKg==}
+    engines: {node: '>=22'}
+
+  starknet@9.1.1:
+    resolution: {integrity: sha512-3Fd4Ygp9zZd0EJBYF1yCWMeiickNN9arANVAvEzarGFy+ysG+CgHK/g9PeI75uo0pq0FHJ8fjUG7zzMyMZxHXQ==}
     engines: {node: '>=22'}
 
   statuses@1.5.0:
@@ -6856,6 +6895,8 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.0': {}
 
+  '@adraffy/ens-normalize@1.11.1': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
@@ -7817,6 +7858,8 @@ snapshots:
 
   '@noble/hashes@1.6.0': {}
 
+  '@noble/hashes@1.6.1': {}
+
   '@noble/hashes@1.7.0': {}
 
   '@noble/hashes@1.7.1': {}
@@ -8611,16 +8654,30 @@ snapshots:
       '@starknet-io/types-js': 0.7.10
       async-mutex: 0.5.0
 
+  '@starknet-io/get-starknet-wallet-standard@5.0.0(typescript@5.9.2)(zod@3.25.76)':
+    dependencies:
+      '@starknet-io/types-js': 0.7.10
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/features': 1.1.0
+      ox: 0.4.4(typescript@5.9.2)(zod@3.25.76)
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
   '@starknet-io/get-starknet@4.0.8':
     dependencies:
       '@starknet-io/get-starknet-core': 4.0.8
       bowser: 2.12.1
+
+  '@starknet-io/types-js@0.10.0': {}
 
   '@starknet-io/types-js@0.7.10': {}
 
   '@starknet-io/types-js@0.8.4': {}
 
   '@starknet-io/types-js@0.9.1': {}
+
+  '@starknet-io/types-js@0.9.2': {}
 
   '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@4.2.20)(vite@4.5.14(@types/node@20.19.12)(terser@5.44.0)))(svelte@4.2.20)(vite@4.5.14(@types/node@20.19.12)(terser@5.44.0))':
     dependencies:
@@ -9134,6 +9191,12 @@ snapshots:
       typescript: 5.9.2
 
   '@vue/shared@3.5.21': {}
+
+  '@wallet-standard/base@1.1.0': {}
+
+  '@wallet-standard/features@1.1.0':
+    dependencies:
+      '@wallet-standard/base': 1.1.0
 
   '@walletconnect/core@2.21.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
@@ -12213,6 +12276,8 @@ snapshots:
 
   lossless-json@4.2.0: {}
 
+  lossless-json@4.3.0: {}
+
   loupe@2.3.7:
     dependencies:
       get-func-name: 2.0.2
@@ -12706,6 +12771,20 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  ox@0.4.4(typescript@5.9.2)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.1.0(typescript@5.9.2)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - zod
 
   ox@0.6.7(typescript@5.9.2)(zod@3.25.76):
     dependencies:
@@ -13779,6 +13858,23 @@ snapshots:
       lossless-json: 4.2.0
       pako: 2.1.0
       ts-mixer: 6.0.4
+
+  starknet@9.1.1(typescript@5.9.2)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.7.0
+      '@noble/hashes': 1.6.1
+      '@scure/base': 1.2.6
+      '@scure/starknet': 1.1.0
+      '@starknet-io/get-starknet-wallet-standard': 5.0.0(typescript@5.9.2)(zod@3.25.76)
+      '@starknet-io/starknet-types-010': '@starknet-io/types-js@0.10.0'
+      '@starknet-io/starknet-types-09': '@starknet-io/types-js@0.9.2'
+      abi-wan-kanabi: 2.2.4
+      lossless-json: 4.3.0
+      pako: 2.1.0
+      ts-mixer: 6.0.4
+    transitivePeerDependencies:
+      - typescript
+      - zod
 
   statuses@1.5.0: {}
 

--- a/src/connectors/argent/argentMobile/index.ts
+++ b/src/connectors/argent/argentMobile/index.ts
@@ -11,8 +11,8 @@ import {
   constants,
   WalletAccount,
   type AccountInterface,
+  type PaymasterInterface,
   type ProviderInterface,
-  type ProviderOptions,
 } from "starknet"
 import {
   ConnectorNotConnectedError,
@@ -130,7 +130,8 @@ export class ArgentMobileBaseConnector extends Connector {
   }
 
   async account(
-    provider: ProviderOptions | ProviderInterface,
+    provider: ProviderInterface,
+    _paymasterProvider?: PaymasterInterface,
   ): Promise<AccountInterface> {
     if (!this._wallet) {
       throw new ConnectorNotConnectedError()

--- a/src/connectors/argent/argentMobile/modal/argentModal.ts
+++ b/src/connectors/argent/argentMobile/modal/argentModal.ts
@@ -173,6 +173,8 @@ class ArgentModal {
       props: {
         layout: modalLayout,
         dappName: modalWallet?.dappName,
+        discoveryWallets: [],
+        installedWallets: [],
         showBackButton: false,
         selectedWallet: modalWallet,
         callback: async (wallet: ModalWallet | null) => {

--- a/src/connectors/braavosMobile/index.ts
+++ b/src/connectors/braavosMobile/index.ts
@@ -7,8 +7,8 @@ import type {
 } from "@starknet-io/types-js"
 import {
   AccountInterface,
+  type PaymasterInterface,
   ProviderInterface,
-  type ProviderOptions,
 } from "starknet"
 import {
   Connector,
@@ -73,7 +73,8 @@ export class BraavosMobileBaseConnector extends Connector {
   }
 
   async account(
-    _: ProviderOptions | ProviderInterface,
+    _: ProviderInterface,
+    _paymasterProvider?: PaymasterInterface,
   ): Promise<AccountInterface> {
     throw new Error("not implemented")
   }

--- a/src/connectors/connector.ts
+++ b/src/connectors/connector.ts
@@ -2,7 +2,7 @@ import EventEmitter from "eventemitter3"
 import {
   AccountInterface,
   ProviderInterface,
-  type ProviderOptions,
+  type PaymasterInterface,
 } from "starknet"
 import type {
   RequestFnCall,
@@ -60,7 +60,8 @@ export abstract class Connector extends EventEmitter<ConnectorEvents> {
   abstract disconnect(): Promise<void>
   /** Get current account silently. Return null if the account is not authorized */
   abstract account(
-    provider: ProviderOptions | ProviderInterface,
+    provider: ProviderInterface,
+    paymasterProvider?: PaymasterInterface,
   ): Promise<AccountInterface>
   /** Get current chain id. */
   abstract chainId(): Promise<bigint>

--- a/src/connectors/controller/index.ts
+++ b/src/connectors/controller/index.ts
@@ -1,4 +1,8 @@
-import type { ProviderOptions, ProviderInterface, AccountInterface } from "starknet"
+import type {
+  AccountInterface,
+  PaymasterInterface,
+  ProviderInterface,
+} from "starknet"
 
 import type {
   RequestFnCall,
@@ -89,7 +93,8 @@ export class ControllerConnector extends Connector {
   }
 
   async account(
-    _provider: ProviderOptions | ProviderInterface,
+    _provider: ProviderInterface,
+    _paymasterProvider?: PaymasterInterface,
   ): Promise<AccountInterface> {
     if (!this.controller) {
       throw new ConnectorNotConnectedError()

--- a/src/connectors/injected/index.ts
+++ b/src/connectors/injected/index.ts
@@ -8,8 +8,8 @@ import {
 import {
   WalletAccount,
   type AccountInterface,
+  type PaymasterInterface,
   type ProviderInterface,
-  type ProviderOptions,
 } from "starknet"
 import {
   ConnectorNotConnectedError,
@@ -159,7 +159,8 @@ export class InjectedConnector extends Connector {
   }
 
   async account(
-    provider: ProviderOptions | ProviderInterface,
+    provider: ProviderInterface,
+    _paymasterProvider?: PaymasterInterface,
   ): Promise<AccountInterface> {
     this.ensureWallet()
     const locked = await this.isLocked()

--- a/src/connectors/keplrMobile/index.ts
+++ b/src/connectors/keplrMobile/index.ts
@@ -7,8 +7,8 @@ import type {
 } from "@starknet-io/types-js"
 import type {
   AccountInterface,
+  PaymasterInterface,
   ProviderInterface,
-  ProviderOptions,
 } from "starknet"
 import {
   Connector,
@@ -67,7 +67,8 @@ export class KeplrMobileBaseConnector extends Connector {
   }
 
   async account(
-    _: ProviderOptions | ProviderInterface,
+    _: ProviderInterface,
+    _paymasterProvider?: PaymasterInterface,
   ): Promise<AccountInterface> {
     throw new Error("not implemented")
   }

--- a/src/connectors/webwallet/index.ts
+++ b/src/connectors/webwallet/index.ts
@@ -11,8 +11,8 @@ import type { TRPCClientError } from "@trpc/client"
 import {
   WalletAccount,
   type AccountInterface,
+  type PaymasterInterface,
   type ProviderInterface,
-  type ProviderOptions,
 } from "starknet"
 import {
   ConnectorNotConnectedError,
@@ -261,7 +261,8 @@ export class WebWalletConnector extends Connector {
   }
 
   async account(
-    provider: ProviderOptions | ProviderInterface,
+    provider: ProviderInterface,
+    _paymasterProvider?: PaymasterInterface,
   ): Promise<AccountInterface> {
     this._wallet = _wallet
 

--- a/src/modal/components/DynamicIcon.svelte
+++ b/src/modal/components/DynamicIcon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { Theme } from "../../types/modal"
-  import { ConnectorIcons } from "../../connectors"
+  import type { Theme } from "../../types/modal"
+  import type { ConnectorIcons } from "../../connectors"
 
   export let theme: Theme
   export let icon: ConnectorIcons

--- a/src/modal/components/buttons/WalletButton.svelte
+++ b/src/modal/components/buttons/WalletButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Callback, ModalWallet, Theme } from "../../../types/modal"
+  import type { Callback, ModalWallet, Theme } from "../../../types/modal"
 
   import LargeButton from "./LargeButton.svelte";
   import DynamicIcon from "../DynamicIcon.svelte"


### PR DESCRIPTION
### Issue / feature description

  Migrate `starknetkit` to Starknet v9 and align connector typing with the newer
  `starknet-react`/`starknet-start` expectations, while keeping behavior and code
  patterns unchanged.

  ### Changes

  - Pin `@starknet-io/get-starknet` and `@starknet-io/get-starknet-core` to `4.0.8`.
  - Update `starknet` dev dependency from `^8.5.2` to pinned `9.1.1`.
  - Update `starknet` peer dependency from `^8.0.0` to `>=9.0.0`.
  - Align connector `account(...)` signatures to `ProviderInterface` plus optional
  `PaymasterInterface` across connector implementations.
  - Remove `ProviderOptions` usage from connector type definitions.
  - Update `pnpm-lock.yaml` to match pinned dependency versions and Starknet v9
  resolution.
  - Apply minimal type-safety follow-ups required by current TS settings (`import
  type` usage and required modal props), without changing runtime behavior.
  - Validate with:
    - `pnpm install --frozen-lockfile --ignore-scripts`
    - `pnpm run check`
    - `pnpm run build`

  ### Checklist

  - [x] Rebased to the last commit of the target branch (or merged)
  - [x] Code self-reviewed
  - [x] Code self-tested
  - [x] Tests updated (if needed)
  - [x] All tests are passing locally